### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For details see the [API reference](http://paurkedal.github.io/ocaml-prime/).
 The library is available though OPAM:
 
     opam repo add paurkedal https://github.com/paurkedal/opam-repo-paurkedal.git
-    opam install ocaml-prime
+    opam install prime
 
 To build form sources, first install the dependencies listed in
 [prime.opam](prime.opam) are installed.


### PR DESCRIPTION
`opam install prime` instead of `opam install ocaml-prime` which throws:
```sh
[ERROR] No package named ocaml-prime found.
```